### PR TITLE
Rank users by score then by first to submit and record user submissions for graphing

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -47,8 +47,9 @@ DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `users` (
-  `username` varchar(64) DEFAULT NULL,
+  `username` varchar(64) NOT NULL,
   `password` varchar(32) DEFAULT NULL,
+  `time` datetime DEFAULT NULL,
   `score` int(11) DEFAULT '9999',
   PRIMARY KEY (`username`)
 ) ENGINE=InnoDB AUTO_INCREMENT=144 DEFAULT CHARSET=latin1;

--- a/schema.sql
+++ b/schema.sql
@@ -49,8 +49,6 @@ DROP TABLE IF EXISTS `users`;
 CREATE TABLE `users` (
   `username` varchar(64) NOT NULL,
   `password` varchar(32) DEFAULT NULL,
-  `time` datetime DEFAULT NULL,
-  `score` int(11) DEFAULT '9999',
   PRIMARY KEY (`username`)
 ) ENGINE=InnoDB AUTO_INCREMENT=144 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -62,6 +60,19 @@ CREATE TABLE `users` (
 LOCK TABLES `users` WRITE;
 /*!40000 ALTER TABLE `users` DISABLE KEYS */;
 /*!40000 ALTER TABLE `users` ENABLE KEYS */;
+UNLOCK TABLES;
+
+DROP TABLE IF EXISTS `submissions`;
+CREATE TABLE `submissions` (
+  `username` varchar(64) NOT NULL,
+  `time` datetime NOT NULL,
+  `score` int(11) NOT NULL,
+  FOREIGN KEY (`username`) REFERENCES users(`username`) ON DELETE CASCADE,
+  PRIMARY KEY `user_score` (`username`, `score`)
+);
+LOCK TABLES `submissions` WRITE;
+/*!40000 ALTER TABLE `submissions` DISABLE KEYS */;
+/*!40000 ALTER TABLE `submissions` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/www/index.php
+++ b/www/index.php
@@ -32,7 +32,7 @@ if(!isset($_GET["page"]) || !in_array($_GET["page"], $valid_pages)) {
 <body>
 	<div class="container">
 		<h1>CodeGolf</h1>
-		<a href="index.php?page=leaderboard">Leaderboard</a> | <a href="index.php?page=register">Account Registration</a> | <a href="index.php?page=challenge">Current Challenge</a> | <a href="index.php?page=script">Submission Script</a>
+		<a href="index.php?page=leaderboard">Leaderboard</a> | <a href="index.php?page=scores">Score Trends</a> | <a href="index.php?page=register">Account Registration</a> | <a href="index.php?page=challenge">Current Challenge</a> | <a href="index.php?page=script">Submission Script</a>
 		<hr/>
 		<?php
 		include($_GET["page"] . ".php");

--- a/www/leaderboard.php
+++ b/www/leaderboard.php
@@ -3,7 +3,7 @@
 if(!defined("IN_MAIN"))
 	error("Invalid access");
 
-$sql = $db->prepare("SELECT username, score FROM users ORDER BY score,username ASC");
+$sql = $db->prepare("SELECT username, score FROM users ORDER BY score,time,username ASC");
 $sql->execute();
 $sql->bind_result($username, $score);
 

--- a/www/leaderboard.php
+++ b/www/leaderboard.php
@@ -3,7 +3,13 @@
 if(!defined("IN_MAIN"))
 	error("Invalid access");
 
-$sql = $db->prepare("SELECT username, score FROM users ORDER BY score,time,username ASC");
+$sql = $db->prepare("SELECT s1.username, s1.score FROM submissions s1 " .
+		"INNER JOIN(" .
+			"SELECT username, MIN(score) AS score FROM submissions " .
+			"GROUP BY username" .
+		") s2 " .
+		"ON s1.username = s2.username AND s1.score = s2.score " .
+		"ORDER BY score,time,username");
 $sql->execute();
 $sql->bind_result($username, $score);
 
@@ -13,8 +19,7 @@ $place = 1;
 
 		<table class="table table-striped table-bordered">
 			<tr><th>Place</th><th>Username</th><th>Best submission (bytes)</th></tr>
-			<?php while($sql->fetch()) {
-				if($score == 9999) continue; ?>
+			<?php while($sql->fetch()) { ?>
 				<tr><td><?php echo $place++; ?></td><td><?php echo $username; ?></td><td><?php echo $score; ?></td></tr>
 			<?php } ?>
 		</table>

--- a/www/scores.php
+++ b/www/scores.php
@@ -11,9 +11,6 @@ $usernames = $res->fetch_all();
 </div>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.min.js"></script>
 <script>
-    function randInt(max_val) {
-        return Math.floor(Math.random() * max_val);
-    }
     var config = {
         type: 'line',
         data: {

--- a/www/scores.php
+++ b/www/scores.php
@@ -1,0 +1,117 @@
+<?php
+mysqli_report(MYSQLI_REPORT_ALL);
+if(!defined("IN_MAIN"))
+	error("Invalid access");
+
+$res = $db->query("SELECT username FROM submissions GROUP BY username ORDER BY username");
+$usernames = $res->fetch_all();
+?>
+
+<div style="width:75%;margin: auto">
+    <canvas id="canvas"></canvas>
+</div>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.min.js"></script>
+<script>
+    function randInt(max_val) {
+        return Math.floor(Math.random() * max_val);
+    }
+    var config = {
+        type: 'line',
+        data: {
+            datasets: [
+            <?php foreach ($usernames as $username) {
+                $username = $username[0];
+            ?>
+            {
+                label: '<?php echo $username; ?>',
+                <?php
+                    $red = rand(0, 255);
+                    $green = rand(0, 255);
+                    $blue = rand(0, 255);
+                    echo "backgroundColor: 'rgb(" . $red . ", " . $green . ", " . $blue . ")',\n";
+                    echo "borderColor: 'rgb(" . $red . ", " . $green . ", " . $blue . ")',\n";
+                ?>
+                data: [
+                    <?php
+                        $scores = $db->prepare("SELECT time, score FROM submissions WHERE username=?");
+                        $scores->bind_param("s", $username);
+                        $scores->execute();
+                        $scores->bind_result($time, $score);
+                        while ($scores->fetch()) {
+                    ?>
+                    { x:'<?php echo $time; ?>', y:<?php echo $score; ?> },
+                    <?php
+                        }
+                        $scores->close();
+                    ?>
+                ],
+                fill: false,
+            },
+            <?php } ?>
+            ]
+        },
+        options: {
+            responsive: true,
+            layout: {
+                padding: {
+                    top:0,
+                }
+            },
+            title: {
+                display: true,
+                text: 'Score Trends',
+                fontSize: 25,
+            },
+            legend: {
+                display: true,
+                position: 'right'
+            },
+            tooltips: {
+                enabled: true,
+            },
+            hover: {
+                mode: 'nearest',
+                intersect: true
+            },
+            elements: {
+                point: {
+//                    radius: 0
+                },
+                line: {
+                    tension: 0
+                }
+            },
+            scales: {
+                xAxes: [{
+                    display: true,
+                    type: 'time',
+                    scaleLabel: {
+                        display: false,
+                        labelString: ''
+                    },
+                    ticks: {
+//                        display: false,
+//                        maxTicksLimit: 20,
+                    }
+                }],
+                yAxes: [{
+                    display: true,
+                    scaleLabel: {
+                        display: true,
+                        labelString: 'Bytes'
+                    },
+                    ticks: {
+//                        stepSize: 1,
+                        maxTicksLimit:20,
+                        min:0,
+                    }
+                }]
+            }
+        }
+    };
+
+    window.onload = function() {
+        var ctx = document.getElementById('canvas').getContext('2d');
+        window.myLine = new Chart(ctx, config);
+    };
+</script>

--- a/www/scores.php
+++ b/www/scores.php
@@ -1,5 +1,4 @@
 <?php
-mysqli_report(MYSQLI_REPORT_ALL);
 if(!defined("IN_MAIN"))
 	error("Invalid access");
 
@@ -74,9 +73,6 @@ $usernames = $res->fetch_all();
                 intersect: true
             },
             elements: {
-                point: {
-//                    radius: 0
-                },
                 line: {
                     tension: 0
                 }
@@ -89,10 +85,6 @@ $usernames = $res->fetch_all();
                         display: false,
                         labelString: ''
                     },
-                    ticks: {
-//                        display: false,
-//                        maxTicksLimit: 20,
-                    }
                 }],
                 yAxes: [{
                     display: true,
@@ -101,7 +93,6 @@ $usernames = $res->fetch_all();
                         labelString: 'Bytes'
                     },
                     ticks: {
-//                        stepSize: 1,
                         maxTicksLimit:20,
                         min:0,
                     }

--- a/www/submit.php
+++ b/www/submit.php
@@ -11,8 +11,8 @@ function error($msg) {
 // output a success message
 function success($username, $score) {
 	global $db;
-        $sql = $db->prepare("SELECT score FROM users WHERE username=?");
-        $sql->bind_param("s", $username);
+	$sql = $db->prepare("SELECT score FROM users WHERE username=?");
+	$sql->bind_param("s", $username);
 	$sql->execute();
 	$sql->bind_result($prev_score);
 	$sql->fetch();

--- a/www/submit.php
+++ b/www/submit.php
@@ -11,10 +11,19 @@ function error($msg) {
 // output a success message
 function success($username, $score) {
 	global $db;
-	$sql = $db->prepare("UPDATE users SET score=LEAST(?, score) WHERE username=?");
-	$sql->bind_param("is", $score, $username);
+        $sql = $db->prepare("SELECT score FROM users WHERE username=?");
+        $sql->bind_param("s", $username);
 	$sql->execute();
+	$sql->bind_result($prev_score);
+	$sql->fetch();
 	$sql->close();
+
+	if ($score < $prev_score) {
+		$sql = $db->prepare("UPDATE users SET score=?, time=NOW() WHERE username=?");
+		$sql->bind_param("is", $score, $username);
+		$sql->execute();
+		$sql->close();
+	}
 	die("Success: code was " . $score . " bytes\n");
 }
 

--- a/www/submit.php
+++ b/www/submit.php
@@ -11,16 +11,16 @@ function error($msg) {
 // output a success message
 function success($username, $score) {
 	global $db;
-	$sql = $db->prepare("SELECT score FROM users WHERE username=?");
+	$sql = $db->prepare("SELECT MIN(score) FROM submissions WHERE username=?");
 	$sql->bind_param("s", $username);
 	$sql->execute();
 	$sql->bind_result($prev_score);
 	$sql->fetch();
 	$sql->close();
 
-	if ($score < $prev_score) {
-		$sql = $db->prepare("UPDATE users SET score=?, time=NOW() WHERE username=?");
-		$sql->bind_param("is", $score, $username);
+	if (is_null($prev_score) || $score < $prev_score) {
+		$sql = $db->prepare("INSERT INTO submissions VALUES (?,NOW(),?)");
+		$sql->bind_param("si", $username, $score);
 		$sql->execute();
 		$sql->close();
 	}


### PR DESCRIPTION
The current leaderboard ranks users by score then by username alphabetically. This pull request changes the leaderboard to rank users by score then time of submission. It also adds a page to show users' scores over time.

1. Submissions are separated into a different table where submission time is also recorded.
2. On user submission, if the new score is less than the old score, the submission is added to the database.
3. Users on the leaderboard are ranked by score, then first to submit, then username
4. A new page is added (score trends) which displays a graph of user scores over time